### PR TITLE
Feature/refresh token callback

### DIFF
--- a/src/components/Main/Login/LoginedMain.tsx
+++ b/src/components/Main/Login/LoginedMain.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import Logo from './Logo';
-import TaskList from './TaskList';
+import { TaskList } from './TaskList';
 import UserInfo from './UserInfo';
 import * as S from '../style';
 import { getAssignment, getBoard } from '../../../modules/reducer/Main';

--- a/src/components/Main/Login/TaskList/index.ts
+++ b/src/components/Main/Login/TaskList/index.ts
@@ -5,4 +5,3 @@ import TaskListComponent from './TaskListComponent';
 import ErrorListComponent from './ErrorListComponent';
 
 export { TaskList, TaskHeader, TaskButton, TaskListComponent, ErrorListComponent };
-export default TaskList;

--- a/src/components/Main/Login/UserInfo/UserInfo.tsx
+++ b/src/components/Main/Login/UserInfo/UserInfo.tsx
@@ -1,17 +1,39 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC, useEffect, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import * as S from '../../style';
 import UserInfoTask from './UserInfoTask';
 import UserInfoButton from './UserInfoButton';
 import { getUserInfo, MainState } from '../../../../modules/reducer/Main';
 import { stateChange, getStateCallback } from '../../../../lib/function';
+import { HeaderState, sendRefreshToken } from '../../../../modules/reducer/Header';
 
 const UserInfo: FC = () => {
-  const { userInfo } = useSelector(getStateCallback<MainState>('Main'));
+  const { userInfo, error } = useSelector(getStateCallback<MainState>('Main'));
+  const { loading, refreshToken } = useSelector(getStateCallback<HeaderState>('Header'));
+  const refreshTokenChange = stateChange(sendRefreshToken);
   const getUserInfoChange = stateChange(getUserInfo);
+  const serverErrorHandler = useCallback((status: number) => {
+    switch (status) {
+      case 401: {
+        const params = {
+          serverType: {
+            refreshToken,
+          },
+          loading,
+          callback: getUserInfoChange,
+        };
+        refreshTokenChange(params);
+      }
+    }
+  }, []);
   useEffect(() => {
     getUserInfoChange();
   }, []);
+  useEffect(() => {
+    if (!error) return;
+    const statusCode = error.response.status;
+    serverErrorHandler(statusCode);
+  }, [error]);
   return (
     <S.UserMain>
       <div>

--- a/src/containers/Main/MainContainer.tsx
+++ b/src/containers/Main/MainContainer.tsx
@@ -4,9 +4,8 @@ import { LoginedMain, LogOutedMain } from '../../components/Main';
 import { getStateCallback } from '../../lib/function/index';
 import { HeaderState } from '../../modules/reducer/Header';
 const Main: FC = () => {
-  const { accessToken } = useSelector(getStateCallback<HeaderState>('Header'));
-  const isLogIn = accessToken.length > 0 ? true : false;
-  return isLogIn ? <LoginedMain /> : <LogOutedMain />;
+  const { isLogin } = useSelector(getStateCallback<HeaderState>('Header'));
+  return isLogin ? <LoginedMain /> : <LogOutedMain />;
 };
 
 export default Main;

--- a/src/lib/api/Header/signin.ts
+++ b/src/lib/api/Header/signin.ts
@@ -17,7 +17,6 @@ export interface SignInThunkType {
 }
 
 export interface RefreshTokenType {
-  callback: Function;
   refreshToken: string;
 }
 
@@ -30,6 +29,7 @@ export interface RefreshTokenResponseType {
 export interface RefreshTokenThunkType {
   serverType: RefreshTokenType;
   loading: boolean;
+  callback: () => void;
 }
 
 export const signin = async (body: SignInType): Promise<SignInResponseType> => {
@@ -37,11 +37,9 @@ export const signin = async (body: SignInType): Promise<SignInResponseType> => {
   return response.data;
 };
 
-export const refreshToken = async (body: RefreshTokenType): Promise<RefreshTokenResponseType> => {
-  try {
-    const response = await getApiDefault().post<RefreshTokenResponseType>('/shank/auth', body);
-    return response.data;
-  } catch (err) {
-    console.log(err);
-  }
+export const sendRefreshToken = async (
+  body: RefreshTokenType,
+): Promise<RefreshTokenResponseType> => {
+  const response = await getApiDefault().post<RefreshTokenResponseType>('/shank/auth', body);
+  return response.data;
 };

--- a/src/lib/api/Header/signup.ts
+++ b/src/lib/api/Header/signup.ts
@@ -33,28 +33,16 @@ export interface EmailSendThunkType {
 }
 
 export const signup = async (body: SignUpType): Promise<AxiosResponse<any>> => {
-  try {
-    const response = await getApiDefault().post('/shank/user', body);
-    return response;
-  } catch (err) {
-    console.log(err);
-  }
+  const response = await getApiDefault().post('/shank/user', body);
+  return response;
 };
 
 export const emailCheck = (body: EmailCheckType): Promise<AxiosResponse<any>> => {
-  try {
-    const response = getApiDefault().put('/shank/user/eamil/verify', body);
-    return response;
-  } catch (err) {
-    console.log(err);
-  }
+  const response = getApiDefault().put('/shank/user/eamil/verify', body);
+  return response;
 };
 
 export const emailSend = (body: EmailSendType): Promise<AxiosResponse<any>> => {
-  try {
-    const response = getApiDefault().post('/shank/user/email/verify', body);
-    return response;
-  } catch (err) {
-    console.log(err);
-  }
+  const response = getApiDefault().post('/shank/user/email/verify', body);
+  return response;
 };

--- a/src/lib/function/index.ts
+++ b/src/lib/function/index.ts
@@ -1,4 +1,5 @@
 import { useDispatch } from 'react-redux';
+import { sendRefreshToken } from 'src/modules/reducer/Header';
 import { reducerType } from '../../modules/reducer';
 import { ErrorType } from '../../modules/reducer/Modal';
 
@@ -16,7 +17,7 @@ export const getStateCallback = <ReturnType>(stateName: string) => (
   return selectedStaet;
 };
 
-export const stateChange = <ValueType>(actionFunc: (ValueType) => any) => {
+export const stateChange = <ValueType>(actionFunc: (value: ValueType) => any) => {
   const dispatch = useDispatch();
   return (value?: ValueType) => {
     dispatch(actionFunc(value));

--- a/src/modules/reducer/Header/index.ts
+++ b/src/modules/reducer/Header/index.ts
@@ -16,6 +16,7 @@ export const SIGNUP_ERROR = 'Header/SIGNUP_ERROR' as const;
 export const EMAILSEND = 'Header/EMAILSEND' as const;
 export const EMAILCHECK = 'Header/EMAILCHECK' as const;
 export const LOADING = 'Header/LOADING' as const;
+export const IS_LOGIN = 'Header/IS_LOGIN' as const;
 
 export const REFRESH_TOKEN_CALL = 'Header/REFRESH_TOKEN_CALL' as const;
 export const REFRESH_TOKEN_FAILURE = 'Header/REFRESH_TOKEN_FAILURE' as const;
@@ -39,6 +40,11 @@ export const sendRefreshToken = refreshTokenThunk();
 
 export const signupErrorChange = (payload: string) => ({
   type: SIGNUP_ERROR,
+  payload,
+});
+
+export const isLoginChange = (payload: boolean) => ({
+  type: IS_LOGIN,
   payload,
 });
 
@@ -71,6 +77,7 @@ export type HeaderState = {
   refreshToken: string;
   loading: boolean;
   error: Error | null;
+  isLogin: boolean;
 };
 
 const getToken = (tokenType: 'accessToken' | 'refreshToken') => {
@@ -86,6 +93,7 @@ const initialState: HeaderState = {
   refreshToken: getToken('refreshToken'),
   loading: false,
   error: null,
+  isLogin: true,
 };
 
 export type HeaderActionType =
@@ -95,7 +103,8 @@ export type HeaderActionType =
   | ReturnType<typeof setAll>
   | ReturnType<typeof setLoading>
   | ReturnType<typeof refreshTokenSuccess>
-  | ReturnType<typeof refreshTokenFailure>;
+  | ReturnType<typeof refreshTokenFailure>
+  | ReturnType<typeof isLoginChange>;
 
 export const HeaderState = (
   state: HeaderState = initialState,
@@ -141,6 +150,12 @@ export const HeaderState = (
         ...state,
         accessToken: action.payload.accessToken,
         refreshToken: action.payload.refreshToken,
+      };
+    }
+    case IS_LOGIN: {
+      return {
+        ...state,
+        isLogin: action.payload,
       };
     }
     default:

--- a/src/modules/reducer/Main/index.ts
+++ b/src/modules/reducer/Main/index.ts
@@ -1,3 +1,4 @@
+import { AxiosError } from 'axios';
 import { AssignmentType, BoardType, UserInfoType } from '../../../lib/api/Assignment/Assignment';
 import { getAssignmentThunk, getBoardThunk, getUserInfoThunk } from '../../thunk/Main';
 
@@ -38,7 +39,7 @@ export const setUserInfo = (payload: UserInfoType) => ({
   payload,
 });
 
-export const getAssignmentFailure = (payload: Error) => ({
+export const getAssignmentFailure = (payload: AxiosError) => ({
   type: GET_ASSIGNMENT_FAILURE,
   payload,
 });
@@ -48,7 +49,7 @@ export const getAssignmentSuccess = (payload: AssignmentType) => ({
   payload,
 });
 
-export const getBoardFailure = (payload: Error) => ({
+export const getBoardFailure = (payload: AxiosError) => ({
   type: GET_BOARD_FAILURE,
   payload,
 });
@@ -63,7 +64,7 @@ export const getUserInfoSuccess = (payload: UserInfoType) => ({
   payload,
 });
 
-export const getUserInfoFailure = (payload: Error) => ({
+export const getUserInfoFailure = (payload: AxiosError) => ({
   type: GET_USER_INFO_FAILURE,
   payload,
 });
@@ -77,7 +78,7 @@ export type MainState = {
   boardPreview: BoardType | null;
   assignmentPreview: AssignmentType | null;
   userInfo: UserInfoType;
-  error: Error | null;
+  error: AxiosError | null;
   loading: boolean;
 };
 

--- a/src/modules/thunk/Header/index.ts
+++ b/src/modules/thunk/Header/index.ts
@@ -1,11 +1,11 @@
 import { RESET, MODAL, ERROR } from '../../reducer/Modal';
-import { ALL, LOADING, REFRESH_TOKEN_SUCCESS } from '../../reducer/Header';
+import { ALL, IS_LOGIN, LOADING, REFRESH_TOKEN_SUCCESS } from '../../reducer/Header';
 import {
   signin,
   SignInThunkType,
   SignInResponseType,
   RefreshTokenThunkType,
-  refreshToken,
+  sendRefreshToken,
 } from '../../../lib/api/Header/signin';
 import { EMAIL_CHECK } from '../../../modules/reducer/SignUp';
 import {
@@ -76,7 +76,6 @@ export const emailSendThunk = () => {
     } catch (err) {
       dispatch({ type: ERROR, payload: 'SignUpEmailError' });
     }
-    dispatch({ type: LOADING, payload: false });
   };
 };
 
@@ -85,7 +84,7 @@ export const refreshTokenThunk = () => {
     if (params.loading) return;
     dispatch({ type: LOADING, payload: true });
     try {
-      const response = await refreshToken(params.serverType);
+      const response = await sendRefreshToken(params.serverType);
       dispatch({
         type: REFRESH_TOKEN_SUCCESS,
         payload: {
@@ -94,7 +93,8 @@ export const refreshTokenThunk = () => {
         },
       });
     } catch (err) {
-      dispatch({ type: err, payload: '' });
+      dispatch({ type: IS_LOGIN, payload: false });
+      dispatch({ type: MODAL, payload: 'SignIn' });
     }
   };
 };

--- a/src/modules/thunk/Main/index.ts
+++ b/src/modules/thunk/Main/index.ts
@@ -8,6 +8,7 @@ import {
   LOADING,
 } from '../../reducer/Main';
 import { getAssignment, getBoard, getUserInfo } from '../../../lib/api/Assignment/Assignment';
+import { IS_LOGIN } from '../../reducer/Header';
 
 export const getBoardThunk = () => {
   return () => async dispatch => {
@@ -15,7 +16,9 @@ export const getBoardThunk = () => {
       dispatch({ type: LOADING, payload: true });
       const payload = await getBoard();
       dispatch({ type: GET_BOARD_SUCCESS, payload });
+      dispatch({ type: IS_LOGIN, payload: true });
     } catch (err) {
+      console.log(err.response);
       dispatch({ type: GET_BOARD_FAILURE, payload: err });
     }
     dispatch({ type: LOADING, payload: false });
@@ -28,7 +31,9 @@ export const getAssignmentThunk = () => {
       dispatch({ type: LOADING, payload: true });
       const payload = await getAssignment();
       dispatch({ type: GET_ASSIGNMENT_SUCCESS, payload });
+      dispatch({ type: IS_LOGIN, payload: true });
     } catch (err) {
+      console.log(err.response);
       dispatch({ type: GET_ASSIGNMENT_FAILURE, payload: err });
     }
     dispatch({ type: LOADING, payload: false });
@@ -41,6 +46,7 @@ export const getUserInfoThunk = () => {
       dispatch({ type: LOADING, payload: true });
       const payload = await getUserInfo;
       dispatch({ type: GET_USER_INFO_SUCCESS, payload });
+      dispatch({ type: IS_LOGIN, payload: true });
     } catch (err) {
       dispatch({ type: GET_USER_INFO_FAILURE, payload: err });
     }


### PR DESCRIPTION
# refresh token 메인에 적용 및 callback 적용
## 목적
모든 이가 refresh token을 이용하여 accessToken 만료 시에 새로운 accessToken을 가져오고 
실패 시 로그인 창을 띄우고 아니면 callback을 실행시킬 수 있게 하기 위해서
## 상세
refresh token에 상세 기능 추가 및 callback 추가.
main에 error handling 추가
## 영향
모든 서버 통신 실패 시 401 에러가 뜨면 refresh token을 해야함
## 관련 pr(선택)
